### PR TITLE
Feedback based on implementing responses in ICARE platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The OperationOutcome will have issue severity value "error" or "fatal" and an is
       - OperationOutcome
         - id -- _identifier of this OperationOutcome resource; referenced above in MessageHeader_
         - issue
-          - severity -- "fatal | error" -- _See [Operation Outcome](https://www.hl7.org/fhir/operationoutcome-examples.html) in the FHIR Specification_
+          - severity -- "fatal | error" -- _See [Operation Outcome](https://www.hl7.org/fhir/operationoutcome) in the FHIR Specification for a reference to the severity ValueSet_
           - code -- _value from the value set,  [issue-type](http://www.hl7.org/implement/standards/fhir/valueset-issue-type.html)_
           - details -- _Optional_
             - text -- _Human-friendly description of the error or reason the ICAREdata system is rejecting the request_

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ See the Implementation Guides for mCODE and ICAREdata Study for constraints of t
 - [mCODE](http://build.fhir.org/ig/HL7/fhir-mCODE-ig/)
 - [ICAREdata Study](http://build.fhir.org/ig/standardhealth/fsh-icare/)
 
-The message header will contain a single data element that reference a Parameters resource that appears in an entry element in the message. The Parameters resource provides information that about the clinical trial and the clinical trial subject that the message pertains too.  
+The message header will contain a single data element that reference a Parameters resource that appears in an entry element in the message. The Parameters resource provides information that about the clinical trial and the clinical trial subject that the message pertains too.
 
 #### Example Message
 
@@ -105,7 +105,7 @@ When the ICAREdata Study submission infrastructure accepts and processes a data 
 
 When the ICAREdata Study submission infrastructure rejects a data submission request, the MessageHeader will have the response code value, "fatal-error" and reference an [OperationOutcome](http://hl7.org/fhir/DSTU2/operationoutcome.html) resource contained in another entry in the bundle.
 
-The OperationOutcome will have issue severity value, "error" and an issue code value from the value set, [issue-type](http://www.hl7.org/implement/standards/fhir/valueset-issue-type.html). The issue code provides ICAREdata Study clients with information about why the submission infrastructure did not process the request. Human-friendly text that complements the issue code may also be provided in an issue details element.
+The OperationOutcome will have issue severity value "error" or "fatal" and an issue code value from the value set, [issue-type](http://www.hl7.org/implement/standards/fhir/valueset-issue-type.html). The issue code provides ICAREdata Study clients with information about why the submission infrastructure did not process the request. Human-friendly text that complements the issue code may also be provided in an issue details element.
 
 #### Message Structure
 
@@ -122,8 +122,8 @@ The OperationOutcome will have issue severity value, "error" and an issue code v
           - system "urn::ICAREdataStudy" -- _namespace for ICAREdata message event code_
           - code  "icare-data-study" -- _code value to denote a submission request message_
         - response
-          - identifier -- _identifier of the message for which this is a response_
-          - code "ok | fatal-error" -- *See [Response Type](http://www.hl7.org/implement/standards/fhir/valueset-response-code.html) in the FHIR Specification*
+          - identifier -- _identifier of the request message for which this is a response; specifically the ID request message's MessageHeader.id_
+          - code "ok | fatal-error" -- _See [Response Type](http://www.hl7.org/implement/standards/fhir/valueset-response-code.html) in the FHIR Specification_
           - details -- _included only if the response code is fatal-error_
             - reference -- _reference to an OperationOutcome resource that contains information about the error_
   - entry -- _Included only if the ICAREdata Study submission system rejected the submission request_
@@ -132,7 +132,7 @@ The OperationOutcome will have issue severity value, "error" and an issue code v
       - OperationOutcome
         - id -- _identifier of this OperationOutcome resource; referenced above in MessageHeader_
         - issue
-          - severity -- "fatal-error" _The literal value, "fatal-error" denotes the ICAREdata system cannot recover from the reported error and will not process the request._
+          - severity -- "fatal | error" -- _See [Operation Outcome](https://www.hl7.org/fhir/operationoutcome-examples.html) in the FHIR Specification_
           - code -- _value from the value set,  [issue-type](http://www.hl7.org/implement/standards/fhir/valueset-issue-type.html)_
           - details -- _Optional_
             - text -- _Human-friendly description of the error or reason the ICAREdata system is rejecting the request_

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The message header will contain a single data element that reference a Parameter
 
 When the ICAREdata Study submission infrastructure accepts and processes a data submission request, the response message will contain a Message Header with response code value, "ok".
 
-When the ICAREdata Study submission infrastructure rejects a data submission request, the MessageHeader will have the response code value, "fatal-error" and reference an [OperationOutcome](http://hl7.org/fhir/DSTU2/operationoutcome.html) resource contained in another entry in the bundle.
+When the ICAREdata Study submission infrastructure rejects a data submission request, the MessageHeader will have the response code value, "fatal-error" and reference an [OperationOutcome](https://www.hl7.org/fhir/operationoutcome.html) resource contained in another entry in the bundle.
 
 The OperationOutcome will have issue severity value "error" or "fatal" and an issue code value from the value set, [issue-type](http://www.hl7.org/implement/standards/fhir/valueset-issue-type.html). The issue code provides ICAREdata Study clients with information about why the submission infrastructure did not process the request. Human-friendly text that complements the issue code may also be provided in an issue details element.
 

--- a/icare-data-submission-response-json-example-01.md
+++ b/icare-data-submission-response-json-example-01.md
@@ -1,5 +1,5 @@
 
-# icare-data-submission Message Example: JSON
+# icare-data-submission Response Message Example: JSON
 
 This example contains the an example response for a successful submission.
 

--- a/icare-data-submission-response-json-example-02.md
+++ b/icare-data-submission-response-json-example-02.md
@@ -34,7 +34,7 @@ The following message returns an error code denoting that a required element in 
         "resourceType": "OperationOutcome",
         "id": "urn:uuid:03f9aa7d-b395-47b9-84e0-053678b6e4e3",
         "issue": {
-          "severity": "fatal-error",
+          "severity": "error",
           "code": "required"
         }
       }


### PR DESCRIPTION
Small changes that clarified some questions I had when implementing the new response format on the ICARE-platform repo. Also moved the index.md to README.md for convenient rendering on GitHub. Let me know if I should change the file back.